### PR TITLE
Added configuration for tidal locking and initial rotation

### DIFF
--- a/Kopernicus/Configuration/Properties.cs
+++ b/Kopernicus/Configuration/Properties.cs
@@ -84,6 +84,20 @@ namespace Kopernicus
 			{
 				set { celestialBody.rotationPeriod = value.value; }
 			}
+
+            // Is the body tidally locked to its parent?
+            [ParserTarget("tidallyLocked", optional = true)]
+            private NumericParser<bool> tidallyLocked
+            {
+                set { celestialBody.tidallyLocked = value.value; }
+            }
+
+            // Initial rotation of the world
+            [ParserTarget("initialRotation", optional = true)]
+            private NumericParser<double> initialRotation
+            {
+                set { celestialBody.initialRotation = value.value; }
+            }
 			
 			// Is this the home world
 			[ParserTarget("isHomeWorld", optional = true)]

--- a/Kopernicus/Configuration/Properties.cs
+++ b/Kopernicus/Configuration/Properties.cs
@@ -84,20 +84,20 @@ namespace Kopernicus
 			{
 				set { celestialBody.rotationPeriod = value.value; }
 			}
+			
+			// Is the body tidally locked to its parent?
+			[ParserTarget("tidallyLocked", optional = true)]
+			private NumericParser<bool> tidallyLocked
+			{
+				set { celestialBody.tidallyLocked = value.value; }
+			}
 
-            // Is the body tidally locked to its parent?
-            [ParserTarget("tidallyLocked", optional = true)]
-            private NumericParser<bool> tidallyLocked
-            {
-                set { celestialBody.tidallyLocked = value.value; }
-            }
-
-            // Initial rotation of the world
-            [ParserTarget("initialRotation", optional = true)]
-            private NumericParser<double> initialRotation
-            {
-                set { celestialBody.initialRotation = value.value; }
-            }
+			// Initial rotation of the world
+			[ParserTarget("initialRotation", optional = true)]
+			private NumericParser<double> initialRotation
+			{
+				set { celestialBody.initialRotation = value.value; }
+			}
 			
 			// Is this the home world
 			[ParserTarget("isHomeWorld", optional = true)]


### PR DESCRIPTION
Hi,

This branch just adds some essential configuration to CelestialBody/Properties node:
1. tidallyLocked (boolean): If set to true, one side of the planet will always face its parent. It will also replace the rotationPeriod value.
2. initialRotation (double): Initial rotation angle for planets, in degrees.