### PR TITLE
Added some PQS mods loader, and fixed a parser bug

### DIFF
--- a/Kopernicus/Configuration/ModLoader/VertexHeightNoiseVertHeightCurve3.cs
+++ b/Kopernicus/Configuration/ModLoader/VertexHeightNoiseVertHeightCurve3.cs
@@ -41,166 +41,166 @@ namespace Kopernicus
 				// Actual PQS mod we are loading
 				private PQSMod_VertexHeightNoiseVertHeightCurve3 _mod;
 
-                // Maximum deformity
-                [ParserTarget("deformityMax")]
-                private NumericParser<double> deformityMax
-                {
-                    set { _mod.deformityMax = value.value; }
-                }
+				// Maximum deformity
+				[ParserTarget("deformityMax")]
+				private NumericParser<double> deformityMax
+				{
+					set { _mod.deformityMax = value.value; }
+				}
 
-                // Minimum deformity
-                [ParserTarget("deformityMin")]
-                private NumericParser<double> deformityMin
-                {
-                    set { _mod.deformityMin = value.value; }
-                }
+				// Minimum deformity
+				[ParserTarget("deformityMin")]
+				private NumericParser<double> deformityMin
+				{
+					set { _mod.deformityMin = value.value; }
+				}
 
-                // Deformity multiplier curve
-                [ParserTarget("inputHeightCurve")]
-                private AnimationCurveParser inputHeightCurve
-                {
-                    set { _mod.inputHeightCurve = value.curve; }
-                }
+				// Deformity multiplier curve
+				[ParserTarget("inputHeightCurve")]
+				private AnimationCurveParser inputHeightCurve
+				{
+					set { _mod.inputHeightCurve = value.curve; }
+				}
 
-                // Ending height
-                [ParserTarget("inputHeightEnd")]
-                private NumericParser<double> inputHeightEnd
-                {
-                    set { _mod.inputHeightEnd = value.value; }
-                }
+				// Ending height
+				[ParserTarget("inputHeightEnd")]
+				private NumericParser<double> inputHeightEnd
+				{
+					set { _mod.inputHeightEnd = value.value; }
+				}
 
-                // Starting height
-                [ParserTarget("inputHeightStart")]
-                private NumericParser<double> inputHeightStart
-                {
-                    set { _mod.inputHeightStart = value.value; }
-                }
+				// Starting height
+				[ParserTarget("inputHeightStart")]
+				private NumericParser<double> inputHeightStart
+				{
+					set { _mod.inputHeightStart = value.value; }
+				}
 
-                // The frequency of the simplex multiplier
-                [ParserTarget("multiplierFrequency", optional = true)]
-                private NumericParser<double> multiplierFrequency
-                {
-                    set { _mod.curveMultiplier.frequency = value.value; }
-                }
+				// The frequency of the simplex multiplier
+				[ParserTarget("multiplierFrequency", optional = true)]
+				private NumericParser<double> multiplierFrequency
+				{
+					set { _mod.curveMultiplier.frequency = value.value; }
+				}
 
-                // Octaves of the simplex multiplier
-                [ParserTarget("multiplierOctaves", optional = true)]
-                private NumericParser<int> multiplierOctaves
-                {
-                    set { _mod.curveMultiplier.octaves = value.value; }
-                }
+				// Octaves of the simplex multiplier
+				[ParserTarget("multiplierOctaves", optional = true)]
+				private NumericParser<int> multiplierOctaves
+				{
+					set { _mod.curveMultiplier.octaves = value.value; }
+				}
 
-                // Persistence of the simplex multiplier
-                [ParserTarget("multiplierPersistence", optional = true)]
-                private NumericParser<double> multiplierPersistence
-                {
-                    set { _mod.curveMultiplier.persistence = value.value; }
-                }
+				// Persistence of the simplex multiplier
+				[ParserTarget("multiplierPersistence", optional = true)]
+				private NumericParser<double> multiplierPersistence
+				{
+					set { _mod.curveMultiplier.persistence = value.value; }
+				}
 
-                // The seed of the simplex multiplier
-                [ParserTarget("multiplierSeed", optional = true)]
-                private NumericParser<int> multiplierSeed
-                {
-                    set { _mod.curveMultiplier.seed = value.value; }
-                }
+				// The seed of the simplex multiplier
+				[ParserTarget("multiplierSeed", optional = true)]
+				private NumericParser<int> multiplierSeed
+				{
+					set { _mod.curveMultiplier.seed = value.value; }
+				}
 
-                // The frequency of the simplex noise on deformity
-                [ParserTarget("deformityFrequency", optional = true)]
-                private NumericParser<double> deformityFrequency
-                {
-                    set { _mod.deformity.frequency = value.value; }
-                }
+				// The frequency of the simplex noise on deformity
+				[ParserTarget("deformityFrequency", optional = true)]
+				private NumericParser<double> deformityFrequency
+				{
+					set { _mod.deformity.frequency = value.value; }
+				}
 
-                // Octaves of the simplex noise on deformity
-                [ParserTarget("deformityOctaves", optional = true)]
-                private NumericParser<int> deformityOctaves
-                {
-                    set { _mod.deformity.octaves = value.value; }
-                }
+				// Octaves of the simplex noise on deformity
+				[ParserTarget("deformityOctaves", optional = true)]
+				private NumericParser<int> deformityOctaves
+				{
+					set { _mod.deformity.octaves = value.value; }
+				}
 
-                // Persistence of the simplex noise on deformity
-                [ParserTarget("deformityPersistence", optional = true)]
-                private NumericParser<double> deformityPersistence
-                {
-                    set { _mod.deformity.persistence = value.value; }
-                }
+				// Persistence of the simplex noise on deformity
+				[ParserTarget("deformityPersistence", optional = true)]
+				private NumericParser<double> deformityPersistence
+				{
+					set { _mod.deformity.persistence = value.value; }
+				}
 
-                // The seed of the simplex noise on deformity
-                [ParserTarget("deformitySeed", optional = true)]
-                private NumericParser<int> deformitySeed
-                {
-                    set { _mod.deformity.seed = value.value; }
-                }
+				// The seed of the simplex noise on deformity
+				[ParserTarget("deformitySeed", optional = true)]
+				private NumericParser<int> deformitySeed
+				{
+					set { _mod.deformity.seed = value.value; }
+				}
 
-                // The frequency of the additive noise
-                [ParserTarget("ridgedAddFrequency", optional = true)]
-                private NumericParser<double> ridgedAddFrequency
-                {
-                    set { _mod.ridgedAdd.frequency = value.value; }
-                }
+				// The frequency of the additive noise
+				[ParserTarget("ridgedAddFrequency", optional = true)]
+				private NumericParser<double> ridgedAddFrequency
+				{
+					set { _mod.ridgedAdd.frequency = value.value; }
+				}
 
-                // Lacunarity of the additive noise
-                [ParserTarget("ridgedAddLacunarity", optional = true)]
-                private NumericParser<double> ridgedAddLacunarity
-                {
-                    set { _mod.ridgedAdd.lacunarity = value.value; }
-                }
+				// Lacunarity of the additive noise
+				[ParserTarget("ridgedAddLacunarity", optional = true)]
+				private NumericParser<double> ridgedAddLacunarity
+				{
+					set { _mod.ridgedAdd.lacunarity = value.value; }
+				}
 
-                // Octaves of the additive noise
-                [ParserTarget("ridgedAddOctaves", optional = true)]
-                private NumericParser<int> ridgedAddOctaves
-                {
-                    set { _mod.ridgedAdd.octaves = value.value; }
-                }
+				// Octaves of the additive noise
+				[ParserTarget("ridgedAddOctaves", optional = true)]
+				private NumericParser<int> ridgedAddOctaves
+				{
+					set { _mod.ridgedAdd.octaves = value.value; }
+				}
 
-                // The quality of the additive noise
-                [ParserTarget("ridgedAddQuality", optional = true)]
-                private EnumParser<LibNoise.Unity.QualityMode> ridgedAddQuality
-                {
-                    set { _mod.ridgedAdd.quality = value.value; }
-                }
+				// The quality of the additive noise
+				[ParserTarget("ridgedAddQuality", optional = true)]
+				private EnumParser<LibNoise.Unity.QualityMode> ridgedAddQuality
+				{
+					set { _mod.ridgedAdd.quality = value.value; }
+				}
 
-                // The seed of the additive noise
-                [ParserTarget("ridgedAddSeed", optional = true)]
-                private NumericParser<int> ridgedAddSeed
-                {
-                    set { _mod.ridgedAdd.seed = value.value; }
-                }
+				// The seed of the additive noise
+				[ParserTarget("ridgedAddSeed", optional = true)]
+				private NumericParser<int> ridgedAddSeed
+				{
+					set { _mod.ridgedAdd.seed = value.value; }
+				}
 
-                // The frequency of the subtractive noise
-                [ParserTarget("ridgedSubFrequency", optional = true)]
-                private NumericParser<double> ridgedSubFrequency
-                {
-                    set { _mod.ridgedSub.frequency = value.value; }
-                }
+				// The frequency of the subtractive noise
+				[ParserTarget("ridgedSubFrequency", optional = true)]
+				private NumericParser<double> ridgedSubFrequency
+				{
+					set { _mod.ridgedSub.frequency = value.value; }
+				}
 
-                // Lacunarity of the subtractive noise
-                [ParserTarget("ridgedSubLacunarity", optional = true)]
-                private NumericParser<double> ridgedSubLacunarity
-                {
-                    set { _mod.ridgedSub.lacunarity = value.value; }
-                }
+				// Lacunarity of the subtractive noise
+				[ParserTarget("ridgedSubLacunarity", optional = true)]
+				private NumericParser<double> ridgedSubLacunarity
+				{
+					set { _mod.ridgedSub.lacunarity = value.value; }
+				}
 
-                // Octaves of the subtractive noise
-                [ParserTarget("ridgedSubOctaves", optional = true)]
-                private NumericParser<int> ridgedSubOctaves
-                {
-                    set { _mod.ridgedSub.octaves = value.value; }
-                }
+				// Octaves of the subtractive noise
+				[ParserTarget("ridgedSubOctaves", optional = true)]
+				private NumericParser<int> ridgedSubOctaves
+				{
+					set { _mod.ridgedSub.octaves = value.value; }
+				}
 
-                // The quality of the subtractive noise
-                [ParserTarget("ridgedSubQuality", optional = true)]
-                private EnumParser<LibNoise.Unity.QualityMode> ridgedSubQuality
-                {
-                    set { _mod.ridgedSub.quality = value.value; }
-                }
+				// The quality of the subtractive noise
+				[ParserTarget("ridgedSubQuality", optional = true)]
+				private EnumParser<LibNoise.Unity.QualityMode> ridgedSubQuality
+				{
+					set { _mod.ridgedSub.quality = value.value; }
+				}
 
-                // The seed of the subtractive noise
-                [ParserTarget("ridgedSubSeed", optional = true)]
-                private NumericParser<int> ridgedSubSeed
-                {
-                    set { _mod.ridgedSub.seed = value.value; }
-                }
+				// The seed of the subtractive noise
+				[ParserTarget("ridgedSubSeed", optional = true)]
+				private NumericParser<int> ridgedSubSeed
+				{
+					set { _mod.ridgedSub.seed = value.value; }
+				}
 
 				void IParserEventSubscriber.Apply(ConfigNode node)
 				{
@@ -219,11 +219,11 @@ namespace Kopernicus
 					modObject.transform.parent = Utility.Deactivator;
 					_mod = modObject.AddComponent <PQSMod_VertexHeightNoiseVertHeightCurve3>();
 
-                    // Construct the internal objects.
-                    _mod.curveMultiplier = new PQSMod_VertexHeightNoiseVertHeightCurve3.SimplexNoise();
-                    _mod.deformity = new PQSMod_VertexHeightNoiseVertHeightCurve3.SimplexNoise();
-                    _mod.ridgedAdd = new PQSMod_VertexHeightNoiseVertHeightCurve3.RidgedNoise();
-                    _mod.ridgedSub = new PQSMod_VertexHeightNoiseVertHeightCurve3.RidgedNoise();
+					// Construct the internal objects.
+					_mod.curveMultiplier = new PQSMod_VertexHeightNoiseVertHeightCurve3.SimplexNoise();
+					_mod.deformity = new PQSMod_VertexHeightNoiseVertHeightCurve3.SimplexNoise();
+					_mod.ridgedAdd = new PQSMod_VertexHeightNoiseVertHeightCurve3.RidgedNoise();
+					_mod.ridgedSub = new PQSMod_VertexHeightNoiseVertHeightCurve3.RidgedNoise();
    
 					base.mod = _mod;
 				}

--- a/Kopernicus/Configuration/ModLoader/VertexHeightNoiseVertHeightCurve3.cs
+++ b/Kopernicus/Configuration/ModLoader/VertexHeightNoiseVertHeightCurve3.cs
@@ -1,0 +1,233 @@
+﻿/**
+ * Kopernicus Planetary System Modifier
+ * Copyright (C) 2014 Bryce C Schroeder (bryce.schroeder@gmail.com), Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ * 
+ * http://www.ferazelhosting.net/~bryce/contact.html
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ * 
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright 2011-2014 Squad. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ * 
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus
+{
+	namespace Configuration
+	{
+		namespace ModLoader
+		{
+			[RequireConfigType(ConfigType.Node)]
+			public class VertexHeightNoiseVertHeightCurve3 : ModLoader, IParserEventSubscriber
+			{
+				// Actual PQS mod we are loading
+				private PQSMod_VertexHeightNoiseVertHeightCurve3 _mod;
+
+                // Maximum deformity
+                [ParserTarget("deformityMax")]
+                private NumericParser<double> deformityMax
+                {
+                    set { _mod.deformityMax = value.value; }
+                }
+
+                // Minimum deformity
+                [ParserTarget("deformityMin")]
+                private NumericParser<double> deformityMin
+                {
+                    set { _mod.deformityMin = value.value; }
+                }
+
+                // Deformity multiplier curve
+                [ParserTarget("inputHeightCurve")]
+                private AnimationCurveParser inputHeightCurve
+                {
+                    set { _mod.inputHeightCurve = value.curve; }
+                }
+
+                // Ending height
+                [ParserTarget("inputHeightEnd")]
+                private NumericParser<double> inputHeightEnd
+                {
+                    set { _mod.inputHeightEnd = value.value; }
+                }
+
+                // Starting height
+                [ParserTarget("inputHeightStart")]
+                private NumericParser<double> inputHeightStart
+                {
+                    set { _mod.inputHeightStart = value.value; }
+                }
+
+                // The frequency of the simplex multiplier
+                [ParserTarget("multiplierFrequency", optional = true)]
+                private NumericParser<double> multiplierFrequency
+                {
+                    set { _mod.curveMultiplier.frequency = value.value; }
+                }
+
+                // Octaves of the simplex multiplier
+                [ParserTarget("multiplierOctaves", optional = true)]
+                private NumericParser<int> multiplierOctaves
+                {
+                    set { _mod.curveMultiplier.octaves = value.value; }
+                }
+
+                // Persistence of the simplex multiplier
+                [ParserTarget("multiplierPersistence", optional = true)]
+                private NumericParser<double> multiplierPersistence
+                {
+                    set { _mod.curveMultiplier.persistence = value.value; }
+                }
+
+                // The seed of the simplex multiplier
+                [ParserTarget("multiplierSeed", optional = true)]
+                private NumericParser<int> multiplierSeed
+                {
+                    set { _mod.curveMultiplier.seed = value.value; }
+                }
+
+                // The frequency of the simplex noise on deformity
+                [ParserTarget("deformityFrequency", optional = true)]
+                private NumericParser<double> deformityFrequency
+                {
+                    set { _mod.deformity.frequency = value.value; }
+                }
+
+                // Octaves of the simplex noise on deformity
+                [ParserTarget("deformityOctaves", optional = true)]
+                private NumericParser<int> deformityOctaves
+                {
+                    set { _mod.deformity.octaves = value.value; }
+                }
+
+                // Persistence of the simplex noise on deformity
+                [ParserTarget("deformityPersistence", optional = true)]
+                private NumericParser<double> deformityPersistence
+                {
+                    set { _mod.deformity.persistence = value.value; }
+                }
+
+                // The seed of the simplex noise on deformity
+                [ParserTarget("deformitySeed", optional = true)]
+                private NumericParser<int> deformitySeed
+                {
+                    set { _mod.deformity.seed = value.value; }
+                }
+
+                // The frequency of the additive noise
+                [ParserTarget("ridgedAddFrequency", optional = true)]
+                private NumericParser<double> ridgedAddFrequency
+                {
+                    set { _mod.ridgedAdd.frequency = value.value; }
+                }
+
+                // Lacunarity of the additive noise
+                [ParserTarget("ridgedAddLacunarity", optional = true)]
+                private NumericParser<double> ridgedAddLacunarity
+                {
+                    set { _mod.ridgedAdd.lacunarity = value.value; }
+                }
+
+                // Octaves of the additive noise
+                [ParserTarget("ridgedAddOctaves", optional = true)]
+                private NumericParser<int> ridgedAddOctaves
+                {
+                    set { _mod.ridgedAdd.octaves = value.value; }
+                }
+
+                // The quality of the additive noise
+                [ParserTarget("ridgedAddQuality", optional = true)]
+                private EnumParser<LibNoise.Unity.QualityMode> ridgedAddQuality
+                {
+                    set { _mod.ridgedAdd.quality = value.value; }
+                }
+
+                // The seed of the additive noise
+                [ParserTarget("ridgedAddSeed", optional = true)]
+                private NumericParser<int> ridgedAddSeed
+                {
+                    set { _mod.ridgedAdd.seed = value.value; }
+                }
+
+                // The frequency of the subtractive noise
+                [ParserTarget("ridgedSubFrequency", optional = true)]
+                private NumericParser<double> ridgedSubFrequency
+                {
+                    set { _mod.ridgedSub.frequency = value.value; }
+                }
+
+                // Lacunarity of the subtractive noise
+                [ParserTarget("ridgedSubLacunarity", optional = true)]
+                private NumericParser<double> ridgedSubLacunarity
+                {
+                    set { _mod.ridgedSub.lacunarity = value.value; }
+                }
+
+                // Octaves of the subtractive noise
+                [ParserTarget("ridgedSubOctaves", optional = true)]
+                private NumericParser<int> ridgedSubOctaves
+                {
+                    set { _mod.ridgedSub.octaves = value.value; }
+                }
+
+                // The quality of the subtractive noise
+                [ParserTarget("ridgedSubQuality", optional = true)]
+                private EnumParser<LibNoise.Unity.QualityMode> ridgedSubQuality
+                {
+                    set { _mod.ridgedSub.quality = value.value; }
+                }
+
+                // The seed of the subtractive noise
+                [ParserTarget("ridgedSubSeed", optional = true)]
+                private NumericParser<int> ridgedSubSeed
+                {
+                    set { _mod.ridgedSub.seed = value.value; }
+                }
+
+				void IParserEventSubscriber.Apply(ConfigNode node)
+				{
+
+				}
+
+				void IParserEventSubscriber.PostApply(ConfigNode node)
+				{
+
+				}
+
+				public VertexHeightNoiseVertHeightCurve3()
+				{
+					// Create the base mod
+					GameObject modObject = new GameObject("VertexHeightNoiseVertHeightCurve3");
+					modObject.transform.parent = Utility.Deactivator;
+					_mod = modObject.AddComponent <PQSMod_VertexHeightNoiseVertHeightCurve3>();
+
+                    // Construct the internal objects.
+                    _mod.curveMultiplier = new PQSMod_VertexHeightNoiseVertHeightCurve3.SimplexNoise();
+                    _mod.deformity = new PQSMod_VertexHeightNoiseVertHeightCurve3.SimplexNoise();
+                    _mod.ridgedAdd = new PQSMod_VertexHeightNoiseVertHeightCurve3.RidgedNoise();
+                    _mod.ridgedSub = new PQSMod_VertexHeightNoiseVertHeightCurve3.RidgedNoise();
+   
+					base.mod = _mod;
+				}
+		}
+	}
+}
+

--- a/Kopernicus/Configuration/ModLoader/VertexHeightNoiseVertHeightCurve3.cs
+++ b/Kopernicus/Configuration/ModLoader/VertexHeightNoiseVertHeightCurve3.cs
@@ -227,7 +227,9 @@ namespace Kopernicus
    
 					base.mod = _mod;
 				}
+			}
 		}
 	}
 }
+
 

--- a/Kopernicus/Configuration/ModLoader/VertexSimplexHeightFlatten.cs
+++ b/Kopernicus/Configuration/ModLoader/VertexSimplexHeightFlatten.cs
@@ -1,0 +1,108 @@
+﻿/**
+ * Kopernicus Planetary System Modifier
+ * Copyright (C) 2014 Bryce C Schroeder (bryce.schroeder@gmail.com), Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ * 
+ * http://www.ferazelhosting.net/~bryce/contact.html
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ * 
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright 2011-2014 Squad. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ * 
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus
+{
+	namespace Configuration
+	{
+		namespace ModLoader
+		{
+			[RequireConfigType(ConfigType.Node)]
+			public class VertexSimplexHeightFlatten : ModLoader, IParserEventSubscriber
+			{
+				// Actual PQS mod we are loading
+				private PQSMod_VertexSimplexHeightFlatten _mod;
+
+				// Cutoff height
+				[ParserTarget("cutoff")]
+				private NumericParser<double> cutoff
+				{
+					set { _mod.cutoff = value.value; }
+				}
+
+				// The deformity of the simplex terrain
+				[ParserTarget("deformity")]
+				private NumericParser<double> deformity
+				{
+					set { _mod.deformity = value.value; }
+				}
+
+				// The frequency of the simplex terrain
+				[ParserTarget("frequency")]
+				private NumericParser<double> frequency
+				{
+					set { _mod.frequency = value.value; }
+				}
+
+				// Octaves of the simplex height
+				[ParserTarget("octaves")]
+				private NumericParser<double> octaves
+				{
+					set { _mod.octaves = value.value; }
+				}
+
+				// Persistence of the simplex height
+				[ParserTarget("persistence")]
+				private NumericParser<double> persistence
+				{
+					set { _mod.persistence = value.value; }
+				}
+
+				// The seed of the simplex height
+				[ParserTarget("seed")]
+				private NumericParser<int> seed
+				{
+					set { _mod.seed = value.value; }
+				}
+
+				void IParserEventSubscriber.Apply(ConfigNode node)
+				{
+
+				}
+
+				void IParserEventSubscriber.PostApply(ConfigNode node)
+				{
+
+				}
+
+				public VertexSimplexHeightFlatten()
+				{
+					// Create the base mod
+					GameObject modObject = new GameObject("VertexSimplexHeightFlatten");
+					modObject.transform.parent = Utility.Deactivator;
+					_mod = modObject.AddComponent<PQSMod_VertexSimplexHeightFlatten>();
+					base.mod = _mod;
+				}
+			}
+		}
+	}
+}
+

--- a/Kopernicus/Configuration/ModLoader/VertexSimplexHeightMap.cs
+++ b/Kopernicus/Configuration/ModLoader/VertexSimplexHeightMap.cs
@@ -1,0 +1,122 @@
+﻿/**
+ * Kopernicus Planetary System Modifier
+ * Copyright (C) 2014 Bryce C Schroeder (bryce.schroeder@gmail.com), Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ * 
+ * http://www.ferazelhosting.net/~bryce/contact.html
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ * 
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright 2011-2014 Squad. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ * 
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus
+{
+	namespace Configuration
+	{
+		namespace ModLoader
+		{
+			[RequireConfigType(ConfigType.Node)]
+			public class VertexSimplexHeightMap : ModLoader, IParserEventSubscriber
+			{
+				// Actual PQS mod we are loading
+				private PQSMod_VertexSimplexHeightMap _mod;
+
+				// The deformity of the simplex terrain
+				[ParserTarget("deformity")]
+				private NumericParser<double> deformity
+				{
+					set { _mod.deformity = value.value; }
+				}
+
+				// The frequency of the simplex terrain
+				[ParserTarget("frequency")]
+				private NumericParser<double> frequency
+				{
+					set { _mod.frequency = value.value; }
+				}
+
+				// Height end
+				[ParserTarget("heightEnd")]
+				private NumericParser<float> heightEnd
+				{
+					set { _mod.heightEnd = value.value; }
+				}
+
+				// Height start
+				[ParserTarget("heightStart")]
+				private NumericParser<float> heightStart
+				{
+					set { _mod.heightStart = value.value; }
+				}
+
+				// The greyscale map texture used
+				[ParserTarget("map")]
+				private MapSOParser_GreyScale<MapSO> heightMap
+				{
+					set { _mod.heightMap = value.value; }
+				}
+
+				// Octaves of the simplex terrain
+				[ParserTarget("octaves")]
+				private NumericParser<double> octaves
+				{
+					set { _mod.octaves = value.value; }
+				}
+
+				// Persistence of the simplex terrain
+				[ParserTarget("persistence")]
+				private NumericParser<double> persistence
+				{
+					set { _mod.persistence = value.value; }
+				}
+
+				// The seed of the simplex terrain
+				[ParserTarget("seed")]
+				private NumericParser<int> seed
+				{
+					set { _mod.seed = value.value; }
+				}
+
+				void IParserEventSubscriber.Apply(ConfigNode node)
+				{
+
+				}
+
+				void IParserEventSubscriber.PostApply(ConfigNode node)
+				{
+
+				}
+
+				public VertexSimplexHeightMap()
+				{
+					// Create the base mod
+					GameObject modObject = new GameObject("VertexSimplexHeightMap");
+					modObject.transform.parent = Utility.Deactivator;
+					_mod = modObject.AddComponent<PQSMod_VertexSimplexHeightMap>();
+					base.mod = _mod;
+				}
+			}
+		}
+	}
+}
+

--- a/Kopernicus/Configuration/ModLoader/VertexSimplexMultiChromatic.cs
+++ b/Kopernicus/Configuration/ModLoader/VertexSimplexMultiChromatic.cs
@@ -1,0 +1,185 @@
+﻿/**
+ * Kopernicus Planetary System Modifier
+ * Copyright (C) 2014 Bryce C Schroeder (bryce.schroeder@gmail.com), Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ * 
+ * http://www.ferazelhosting.net/~bryce/contact.html
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ * 
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright 2011-2014 Squad. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ * 
+ * https://kerbalspaceprogram.com
+ */
+
+using System;
+using UnityEngine;
+
+namespace Kopernicus
+{
+	namespace Configuration
+	{
+		namespace ModLoader
+		{
+			[RequireConfigType(ConfigType.Node)]
+			public class VertexSimplexMultiChromatic : ModLoader, IParserEventSubscriber
+			{
+				// Actual PQS mod we are loading
+				private PQSMod_VertexSimplexMultiChromatic _mod;
+
+				// The frequency of the alpha noise
+				[ParserTarget("alphaFrequency")]
+				private NumericParser<double> alphaFrequency
+				{
+					set { _mod.alphaFrequency = value.value; }
+				}
+
+				// Octaves of the alpha noise
+				[ParserTarget("alphaOctaves")]
+				private NumericParser<double> alphaOctaves
+				{
+					set { _mod.alphaOctaves = value.value; }
+				}
+
+				// Persistence of the alpha noise
+				[ParserTarget("alphaPersistence")]
+				private NumericParser<double> alphaPersistence
+				{
+					set { _mod.alphaPersistence = value.value; }
+				}
+
+				// The seed of the alpha noise
+				[ParserTarget("alphaSeed")]
+				private NumericParser<int> alphaSeed
+				{
+					set { _mod.alphaSeed = value.value; }
+				}
+
+				// Amount of color that will be applied
+				[ParserTarget("blend")]
+				private NumericParser<float> blend
+				{
+					set { _mod.blend = value.value; }
+				}
+
+				// The frequency of the blue noise
+				[ParserTarget("blueFrequency")]
+				private NumericParser<double> blueFrequency
+				{
+					set { _mod.blueFrequency = value.value; }
+				}
+
+				// Octaves of the blue noise
+				[ParserTarget("blueOctaves")]
+				private NumericParser<double> blueOctaves
+				{
+					set { _mod.blueOctaves = value.value; }
+				}
+
+				// Persistence of the blue noise
+				[ParserTarget("bluePersistence")]
+				private NumericParser<double> bluePersistence
+				{
+					set { _mod.bluePersistence = value.value; }
+				}
+
+				// The seed of the blue noise
+				[ParserTarget("blueSeed")]
+				private NumericParser<int> blueSeed
+				{
+					set { _mod.blueSeed = value.value; }
+				}
+
+				// The frequency of the green noise
+				[ParserTarget("greenFrequency")]
+				private NumericParser<double> greenFrequency
+				{
+					set { _mod.greenFrequency = value.value; }
+				}
+
+				// Octaves of the green noise
+				[ParserTarget("greenOctaves")]
+				private NumericParser<double> greenOctaves
+				{
+					set { _mod.greenOctaves = value.value; }
+				}
+
+				// Persistence of the green noise
+				[ParserTarget("greenPersistence")]
+				private NumericParser<double> greenPersistence
+				{
+					set { _mod.greenPersistence = value.value; }
+				}
+
+				// The seed of the green noise
+				[ParserTarget("greenSeed")]
+				private NumericParser<int> greenSeed
+				{
+					set { _mod.greenSeed = value.value; }
+				}
+
+				// The frequency of the red noise
+				[ParserTarget("redFrequency")]
+				private NumericParser<double> redFrequency
+				{
+					set { _mod.redFrequency = value.value; }
+				}
+
+				// Octaves of the red noise
+				[ParserTarget("redOctaves")]
+				private NumericParser<double> redOctaves
+				{
+					set { _mod.redOctaves = value.value; }
+				}
+
+				// Persistence of the red noise
+				[ParserTarget("redPersistence")]
+				private NumericParser<double> redPersistence
+				{
+					set { _mod.redPersistence = value.value; }
+				}
+
+				// The seed of the red noise
+				[ParserTarget("redSeed")]
+				private NumericParser<int> redSeed
+				{
+					set { _mod.redSeed = value.value; }
+				}
+
+				void IParserEventSubscriber.Apply(ConfigNode node)
+				{
+
+				}
+
+				void IParserEventSubscriber.PostApply(ConfigNode node)
+				{
+
+				}
+
+				public VertexSimplexMultiChromatic()
+				{
+					// Create the base mod
+					GameObject modObject = new GameObject("VertexSimplexMultiChromatic");
+					modObject.transform.parent = Utility.Deactivator;
+					_mod = modObject.AddComponent<PQSMod_VertexSimplexMultiChromatic>();
+					base.mod = _mod;
+				}
+			}
+		}
+	}
+}
+

--- a/Kopernicus/Configuration/Parser/BuiltinTypeParsers.cs
+++ b/Kopernicus/Configuration/Parser/BuiltinTypeParsers.cs
@@ -456,7 +456,7 @@ namespace Kopernicus
 			}
 
 			// Construct this fine object
-			public AnimationCurveParser (AnimationCurve curve = null)
+			public AnimationCurveParser (AnimationCurve curve)
 			{
 				this.curve = curve;
 			}
@@ -522,13 +522,13 @@ namespace Kopernicus
 			void IParserEventSubscriber.PostApply(ConfigNode node) { }
 
 			// Default constructor
-			public PhysicsMaterialParser()
+			public PhysicsMaterialParser ()
 			{
 				this.material = null;
 			}
 
 			// Initializing constructor
-			public PhysicsMaterialParser (PhysicMaterial material = null)
+			public PhysicsMaterialParser (PhysicMaterial material)
 			{
 				this.material = material;
 			}

--- a/Kopernicus/Configuration/Parser/BuiltinTypeParsers.cs
+++ b/Kopernicus/Configuration/Parser/BuiltinTypeParsers.cs
@@ -449,6 +449,12 @@ namespace Kopernicus
 			// We don't use this
 			void IParserEventSubscriber.PostApply(ConfigNode node) { }
 
+			// Default constructor
+			public AnimationCurveParser ()
+			{
+				this.curve = null;
+			}
+
 			// Construct this fine object
 			public AnimationCurveParser (AnimationCurve curve = null)
 			{
@@ -514,6 +520,12 @@ namespace Kopernicus
 
 			void IParserEventSubscriber.Apply(ConfigNode node) { }
 			void IParserEventSubscriber.PostApply(ConfigNode node) { }
+
+			// Default constructor
+			public PhysicsMaterialParser()
+			{
+				this.material = null;
+			}
 
 			// Initializing constructor
 			public PhysicsMaterialParser (PhysicMaterial material = null)

--- a/Kopernicus/Kopernicus.csproj
+++ b/Kopernicus/Kopernicus.csproj
@@ -66,8 +66,10 @@
     <Compile Include="Configuration\ModLoader\VertexHeightNoise.cs" />
     <Compile Include="Configuration\ModLoader\AerialPerspectiveMaterial.cs" />
     <Compile Include="Configuration\ModLoader\VertexHeightNoiseHeightMap.cs" />
+    <Compile Include="Configuration\ModLoader\VertexHeightNoiseVertHeightCurve3.cs" />
     <Compile Include="Configuration\ModLoader\VertexNoise.cs" />
     <Compile Include="Configuration\ModLoader\VertexSimplexHeightFlatten.cs" />
+    <Compile Include="Configuration\ModLoader\VertexSimplexHeightMap.cs" />
     <Compile Include="Configuration\ModLoader\VertexSimplexMultiChromatic.cs" />
     <Compile Include="Configuration\ModLoader\VertexVoronoi.cs" />
     <Compile Include="Configuration\ModLoader\VertexHeightOffset.cs" />

--- a/Kopernicus/Kopernicus.csproj
+++ b/Kopernicus/Kopernicus.csproj
@@ -67,6 +67,8 @@
     <Compile Include="Configuration\ModLoader\AerialPerspectiveMaterial.cs" />
     <Compile Include="Configuration\ModLoader\VertexHeightNoiseHeightMap.cs" />
     <Compile Include="Configuration\ModLoader\VertexNoise.cs" />
+    <Compile Include="Configuration\ModLoader\VertexSimplexHeightFlatten.cs" />
+    <Compile Include="Configuration\ModLoader\VertexSimplexMultiChromatic.cs" />
     <Compile Include="Configuration\ModLoader\VertexVoronoi.cs" />
     <Compile Include="Configuration\ModLoader\VertexHeightOffset.cs" />
     <Compile Include="Configuration\ModLoader\VertexHeightOblate.cs" />


### PR DESCRIPTION
Added some more PQS mods loader. Each of them have been tested, and seemed to work correctly.

When testing one of the mods (VertHeightCurve3), I found a problem when passing an AnimationCurve parameter to the mod. It turned out that the CreateInstance static function of Activator class (Parser.cs:58) wouldn't regard constructor with optional parameters on all of them as a default constructor (i.e. the one that takes no parameter).

Therefore, I added a default constructor to AnimationCurveParser, and additionally, to PhysicsMaterialParser. And it seems to solve the problem.