### PR TITLE
Allow PQS cache file location to be explicitly specified

### DIFF
--- a/Kopernicus/Configuration/Body.cs
+++ b/Kopernicus/Configuration/Body.cs
@@ -65,6 +65,9 @@ namespace Kopernicus
             }
             private string _name;
 
+            [ParserTarget("cacheFile", optional = true)]
+            public string cacheFile { get; set; }
+
 			[ParserTarget("cbNameLater", optional = true)]
             private string cbNameLater
             {
@@ -343,10 +346,12 @@ namespace Kopernicus
                         (((template != null) && (Math.Abs(template.radius - generatedBody.celestialBody.Radius) > 1.0 || template.type != scaledVersion.type.value))
                         || template == null || inEveryCase))
                     {
+
                         Utility.UpdateScaledMesh(generatedBody.scaledVersion,
                                                     generatedBody.pqsVersion,
                                                     generatedBody.celestialBody,
                                                     ScaledSpaceCacheDirectory,
+                                                    cacheFile,
                                                     exportBin,
                                                     scaledVersion.useSphericalModel);
                     }

--- a/Kopernicus/PostInject.cs
+++ b/Kopernicus/PostInject.cs
@@ -384,7 +384,7 @@ namespace Kopernicus
                         bool useSphere = false;
                         if (node.HasValue("sphericalModel"))
                             bool.TryParse(node.GetValue("sphericalModel"), out useSphere);
-                        Utility.UpdateScaledMesh(ssObj, body.pqsController, body, "GameData/Kopernicus/Cache", true, useSphere);
+                        Utility.UpdateScaledMesh(ssObj, body.pqsController, body, "GameData/Kopernicus/Cache", node.GetValue("cacheFile"), true, useSphere);
                     }
                     else
                         Logger.Active.Log("Could not find a scaledVersion to remake.");

--- a/Kopernicus/Utility.cs
+++ b/Kopernicus/Utility.cs
@@ -317,7 +317,7 @@ namespace Kopernicus
 
         }
 
-        public static void UpdateScaledMesh(GameObject scaledVersion, PQS pqs, CelestialBody body, string path, bool exportBin, bool useSpherical)
+        public static void UpdateScaledMesh(GameObject scaledVersion, PQS pqs, CelestialBody body, string path, string cacheFile, bool exportBin, bool useSpherical)
         {
             const double rJool = 6000000.0;
             const float rScaled = 1000.0f;
@@ -330,7 +330,17 @@ namespace Kopernicus
             // Attempt to load a cached version of the scale space
             string CacheDirectory = KSPUtil.ApplicationRootPath + path;
             string CacheFile = CacheDirectory + "/" + body.name + ".bin";
+
+            if (!string.IsNullOrEmpty(cacheFile))
+            {
+                CacheFile = Path.Combine(Path.Combine(KSPUtil.ApplicationRootPath, "GameData"), cacheFile);
+                CacheDirectory = Path.GetDirectoryName(CacheFile);
+
+                Logger.Active.Log(string.Format("[Kopernicus]: {0} is using custom cache file '{1}' in '{2}'", body.name, CacheFile, CacheDirectory));
+            }
+
             Directory.CreateDirectory(CacheDirectory);
+
             if (File.Exists(CacheFile) && exportBin)
             {
                 Logger.Active.Log("[Kopernicus]: Body.PostApply(ConfigNode): Loading cached scaled space mesh: " + body.name);


### PR DESCRIPTION
This allows `Body` configuration nodes to optionally specify a `cacheFile` property, which is a `GameData` relative path to the file to be used for the PQS cache. If not specified, the current behavior is used.

This will allow mods to distribute/build the cache files inside their own directories, making mod management easier for users.

I tested this by downloading the latest Kopernicus release, replacing the assembly with one built from this version of the code, editing the Kopernicus example planet to have a `cacheFile` property, and then observing Kopernicus writing the cache file to the specified location.