### PR TITLE
Fix altEnd value in ModLoader/HeightColorMap.cs

### DIFF
--- a/Kopernicus/Configuration/ModLoader/HeightColorMap.cs
+++ b/Kopernicus/Configuration/ModLoader/HeightColorMap.cs
@@ -77,7 +77,7 @@ namespace Kopernicus
 					[ParserTarget("altitudeEnd")]
 					private NumericParser<double> altitudeEnd
 					{
-						set { landClass.altStart = value.value; }
+						set { landClass.altEnd = value.value; }
 					}
 
 					// Should we blend into the next class


### PR DESCRIPTION
This completely prevents HeightColorMap's from showing more than 1 land class at a time. It's bad, this fixes it.