### PR TITLE
CelestialBodyTransform.planetFade configuration

### DIFF
--- a/Kopernicus/Configuration/ModLoader/HeightColorMap.cs
+++ b/Kopernicus/Configuration/ModLoader/HeightColorMap.cs
@@ -77,7 +77,7 @@ namespace Kopernicus
 					[ParserTarget("altitudeEnd")]
 					private NumericParser<double> altitudeEnd
 					{
-						set { landClass.altStart = value.value; }
+						set { landClass.altEnd = value.value; }
 					}
 
 					// Should we blend into the next class

--- a/Kopernicus/Configuration/PQSLoader.cs
+++ b/Kopernicus/Configuration/PQSLoader.cs
@@ -100,13 +100,13 @@ namespace Kopernicus
 
 			// CelestialBodyTransform fades. should more or less line up with ScaledVersion's fadeStart/fadeEnd
 			[ParserTarget("pqsFadeStart", optional = true)]
-			private NumericParser<double> fadeStart
+			private NumericParser<float> fadeStart
 			{
 				set { transform.planetFade.fadeStart = value.value; }
 			}
 
 			[ParserTarget("pqsFadeEnd", optional = true)]
-			private NumericParser<double> fadeEnd
+			private NumericParser<float> fadeEnd
 			{
 				set { transform.planetFade.fadeEnd = value.value; }
 			}

--- a/Kopernicus/Configuration/PQSLoader.cs
+++ b/Kopernicus/Configuration/PQSLoader.cs
@@ -98,6 +98,19 @@ namespace Kopernicus
 				set { pqsVersion.maxQuadLenghtsPerFrame = value.value; }
 			}
 
+			// CelestialBodyTransform fades. should more or less line up with ScaledVersion's fadeStart/fadeEnd
+			[ParserTarget("pqsFadeStart", optional = true)]
+			private NumericParser<double> fadeStart
+			{
+				set { transform.planetFade.fadeStart = value.value; }
+			}
+
+			[ParserTarget("pqsFadeEnd", optional = true)]
+			private NumericParser<double> fadeEnd
+			{
+				set { transform.planetFade.fadeEnd = value.value; }
+			}
+
 			[PreApply]
 			[ParserTarget("materialType", optional = true)]
 			private EnumParser<PQSMaterialType> materialType


### PR DESCRIPTION
I didn't see anywhere in the code that allowed configuration of the PQS's fade values, and since they were locked at 100km and 110km in the PQSLoader constructor, whenever the scaledspace fader values were set to anything higher than 110km, the PQS would fade away, and then there would be no planet until the scaled version faded in.

Also, for some reason, my previous pull request was bundled up with this one, but it shouldn't adversely affect anything.