### PR TITLE
ExternalParserTargets, adding ParserTargets from other assemblies

### DIFF
--- a/Kopernicus/Configuration/Body.cs
+++ b/Kopernicus/Configuration/Body.cs
@@ -48,6 +48,9 @@ namespace Kopernicus
 		[RequireConfigType(ConfigType.Node)]
 		public class Body : IParserEventSubscriber
 		{
+			// The body currently loading. Used by the ExternalParserTargetLoader.
+			internal static Body CurrentLoadingBody { get; private set; }
+
             // Path of the plugin (will eventually not matter much)
             public const string ScaledSpaceCacheDirectory = "GameData/Kopernicus/Cache";
 
@@ -138,6 +141,9 @@ namespace Kopernicus
 			// Parser Apply Event
 			public void Apply (ConfigNode node)
 			{
+				// Set the current loading body to this, so that ExternalParserTargets know what to change
+				CurrentLoadingBody = this;
+
 				// If we have a template, generatedBody *is* the template body
 				if (template != null) 
 				{

--- a/Kopernicus/Configuration/ExternalParserTargetLoader.cs
+++ b/Kopernicus/Configuration/ExternalParserTargetLoader.cs
@@ -44,6 +44,10 @@ namespace Kopernicus
 		 **/
 		public class ExternalParserTargetLoader
 		{
+			public ExternalParserTargetLoader()
+			{
+			}
+
 			// Value is set by parser before loading
 			public PSystemBody generatedBody { get; internal set; }
 		}

--- a/Kopernicus/Configuration/ExternalParserTargetLoader.cs
+++ b/Kopernicus/Configuration/ExternalParserTargetLoader.cs
@@ -1,0 +1,52 @@
+﻿/**
+ * Kopernicus Planetary System Modifier
+ * ====================================
+ * Created by: - Bryce C Schroeder (bryce.schroeder@gmail.com)
+ * 			   - Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ * 
+ * Maintained by: - Thomas P.
+ * 				  - NathanKell
+ * 
+* Additional Content by: Gravitasi, aftokino, KCreator, Padishar, Kragrathea, OvenProofMars, zengei, MrHappyFace
+ * ------------------------------------------------------------- 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ * 
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright 2011-2014 Squad. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ * 
+ * https://kerbalspaceprogram.com
+ * 
+ * Code based on KittiopaTech, modified by Thomas P.
+ */
+
+using System;
+
+namespace Kopernicus
+{
+	namespace Configuration
+	{
+		/**
+		 * Class all ExternalParserTargets must extend
+		 **/
+		public class ExternalParserTargetLoader
+		{
+			// Value is set by parser before loading
+			public PSystemBody generatedBody { get; internal set; }
+		}
+	}
+}
+

--- a/Kopernicus/Configuration/Parser/Attributes/ExternalParserTarget.cs
+++ b/Kopernicus/Configuration/Parser/Attributes/ExternalParserTarget.cs
@@ -1,0 +1,62 @@
+﻿/**
+ * Kopernicus Planetary System Modifier
+ * ====================================
+ * Created by: - Bryce C Schroeder (bryce.schroeder@gmail.com)
+ * 			   - Nathaniel R. Lewis (linux.robotdude@gmail.com)
+ * 
+ * Maintained by: - Thomas P.
+ * 				  - NathanKell
+ * 
+* Additional Content by: Gravitasi, aftokino, KCreator, Padishar, Kragrathea, OvenProofMars, zengei, MrHappyFace
+ * ------------------------------------------------------------- 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ * 
+ * This library is intended to be used as a plugin for Kerbal Space Program
+ * which is copyright 2011-2014 Squad. Your usage of Kerbal Space Program
+ * itself is governed by the terms of its EULA, not the license above.
+ * 
+ * https://kerbalspaceprogram.com
+ * 
+ * Code based on KittiopaTech, modified by Thomas P.
+ */
+
+using System;
+
+namespace Kopernicus
+{
+	namespace Configuration
+	{
+		/**
+		 * Attribute used to tag a class in another library to add it to the ParserTargets for Body
+		 **/
+		[AttributeUsage(AttributeTargets.Class)]
+		public class ExternalParserTarget : Attribute
+		{
+			// Like the ParserTarget, if null, this will be determined via reflection
+			public string configNodeName = null;
+
+			// The parser will look for this in the node with this name
+			public string parentNodeName = "Body";
+
+			// Constructor sets name
+			public ExternalParserTarget(string configNodeName = null)
+			{
+				this.configNodeName = configNodeName;
+			}
+		}
+	}
+}
+

--- a/Kopernicus/Configuration/Parser/Parser.cs
+++ b/Kopernicus/Configuration/Parser/Parser.cs
@@ -158,11 +158,11 @@ namespace Kopernicus
 							{
 								try
 								{
+									Logger.Active.Log("Parsing ExternalTarget " + externalAttr.configNodeName + " in node " + externalAttr.parentNodeName + " from Assembly " + assembly.assembly.FullName);
 									var nodeToLoad = node.GetNode (externalAttr.configNodeName);
 									ExternalParserTargetLoader obj = Activator.CreateInstance (type) as ExternalParserTargetLoader;
 									obj.generatedBody = Body.CurrentLoadingBody.generatedBody;
 									Parser.LoadObjectFromConfigurationNode (obj, nodeToLoad);
-									Logger.Active.Log("Parsing ExternalTarget " + externalAttr.configNodeName + " in node " + externalAttr.parentNodeName + " from Assembly " + assembly.assembly.FullName);
 								}
 								catch(MissingMethodException missingMethod)
 								{

--- a/Kopernicus/Configuration/Parser/Parser.cs
+++ b/Kopernicus/Configuration/Parser/Parser.cs
@@ -162,6 +162,7 @@ namespace Kopernicus
 									ExternalParserTargetLoader obj = Activator.CreateInstance (type) as ExternalParserTargetLoader;
 									obj.generatedBody = Body.CurrentLoadingBody.generatedBody;
 									Parser.LoadObjectFromConfigurationNode (obj, nodeToLoad);
+									Logger.Active.Log("Parsing ExternalTarget " + externalAttr.configNodeName + " in node " + externalAttr.parentNodeName + " from Assembly " + assembly.assembly.FullName);
 								}
 								catch(MissingMethodException missingMethod)
 								{

--- a/Kopernicus/Configuration/Parser/Parser.cs
+++ b/Kopernicus/Configuration/Parser/Parser.cs
@@ -132,7 +132,7 @@ namespace Kopernicus
 				// Look for types in other assemblies with the ExternalParserTarget attribute and the parentNodeName equal to this node's name
 				foreach (AssemblyLoader.LoadedAssembly assembly in AssemblyLoader.loadedAssemblies)
 				{
-					// Only get types implementing IParserEventSubscriber, and extending 
+					// Only get types implementing IParserEventSubscriber, and extending ExternalParserTargetLoader
 					foreach (Type type in assembly.assembly.GetExportedTypes().Where(t => t.GetInterface("IParserEventSubscriber") != null).Where(t => t.BaseType == typeof(ExternalParserTargetLoader)))
 					{
 						ExternalParserTarget externalAttr = null;
@@ -163,10 +163,15 @@ namespace Kopernicus
 									obj.generatedBody = Body.CurrentLoadingBody.generatedBody;
 									Parser.LoadObjectFromConfigurationNode (obj, nodeToLoad);
 								}
-								catch (InvalidCastException invalidCast)
+								catch(MissingMethodException missingMethod)
+								{
+									Logger.Active.Log ("Failed to load ExternalParserTarget " + externalAttr.configNodeName + " because it does not have a parameterless constructor");
+									Logger.Active.LogException (missingMethod);
+								}
+								catch (Exception exception)
 								{
 									Logger.Active.Log ("Failed to load ExternalParserTarget " + externalAttr.configNodeName + " from node " + externalAttr.parentNodeName);
-									Logger.Active.LogException (invalidCast);
+									Logger.Active.LogException (exception);
 								}
 							}
 						}

--- a/Kopernicus/Configuration/Parser/Parser.cs
+++ b/Kopernicus/Configuration/Parser/Parser.cs
@@ -129,6 +129,50 @@ namespace Kopernicus
 					}
 				}
 
+				// Look for types in other assemblies with the ExternalParserTarget attribute and the parentNodeName equal to this node's name
+				foreach (AssemblyLoader.LoadedAssembly assembly in AssemblyLoader.loadedAssemblies)
+				{
+					// Only get types implementing IParserEventSubscriber, and extending 
+					foreach (Type type in assembly.assembly.GetExportedTypes().Where(t => t.GetInterface("IParserEventSubscriber") != null).Where(t => t.BaseType == typeof(ExternalParserTargetLoader)))
+					{
+						ExternalParserTarget externalAttr = null;
+
+						var attributes = Attribute.GetCustomAttributes(type);
+						foreach (var attr in attributes.Where (a => a.GetType () == typeof(ExternalParserTarget)))
+						{
+							externalAttr = attr as ExternalParserTarget;
+						}
+
+						if (externalAttr != null)
+						{
+							if (node.name != externalAttr.parentNodeName)
+								continue;
+
+							string nodeName = externalAttr.configNodeName;
+							if (nodeName == null)
+							{
+								nodeName = type.Name;
+							}
+
+							if(node.HasNode(externalAttr.configNodeName))
+							{
+								try
+								{
+									var nodeToLoad = node.GetNode (externalAttr.configNodeName);
+									ExternalParserTargetLoader obj = Activator.CreateInstance (type) as ExternalParserTargetLoader;
+									obj.generatedBody = Body.CurrentLoadingBody.generatedBody;
+									Parser.LoadObjectFromConfigurationNode (obj, nodeToLoad);
+								}
+								catch (InvalidCastException invalidCast)
+								{
+									Logger.Active.Log ("Failed to load ExternalParserTarget " + externalAttr.configNodeName + " from node " + externalAttr.parentNodeName);
+									Logger.Active.LogException (invalidCast);
+								}
+							}
+						}
+					}
+				}
+
 				// Call PostApply
 				if (subscriber != null)
 					subscriber.PostApply (node);


### PR DESCRIPTION
I added a small bit to the Parser that looks for classes in all the loaded assemblies that have the ExternalParserTarget atribute and extend ExternalParserTargetLoader, and loads them in as if they were regular ParserTargets.  
This would allow plugin developers to extend the configuration system of Kopernicus in there own plugins beyond adding custom ModLoaders.

I made an example
one that adds my glowing ocean effect, ([code here](https://gist.github.com/HappyFaceIndustries/5cf0fdc4d9805d0168c1#file-emissiveoceanloader)) and it loads flawlessly. Even when it wasn't loading flawlessly, it still didn't break the rest of Kopernicus's functionality in any way.

[Image](https://cloud.githubusercontent.com/assets/7258677/8561166/83bf8e32-24e6-11e5-86d5-ffa99ccaaba9.png)